### PR TITLE
Update some GitHub Actions

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -25,7 +25,7 @@ jobs:
       run: composer install --prefer-dist --no-progress
 
     - name: Setup Node.js environment
-      uses: actions/setup-node@v2.4.0
+      uses: actions/setup-node@v3
       with:
         cache: 'yarn'
 

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Setup PHP 8.1
-      uses: shivammathur/setup-php@2.13.0
+      uses: shivammathur/setup-php@v2
       with:
         php-version: '8.1'
 

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup PHP 8.1
       uses: shivammathur/setup-php@2.13.0

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup PHP 7.4
+    - name: Setup PHP 8.1
       uses: shivammathur/setup-php@2.13.0
       with:
-        php-version: '7.4'
+        php-version: '8.1'
 
     - name: Validate composer.json and composer.lock
       run: composer validate --strict

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -31,5 +31,7 @@ jobs:
 
     - run: yarn install
 
+    - run: yarn run build
+
     - name: Run tests
       run: vendor/bin/simple-phpunit

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -31,7 +31,5 @@ jobs:
 
     - run: yarn install
 
-    - run: yarn heroku-postbuild
-
     - name: Run tests
       run: vendor/bin/simple-phpunit

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "damienalexandre/jolitypo-website",
-    "description": "Demo wesbite for jolicode/jolitypo",
+    "description": "Demo website for jolicode/jolitypo",
     "authors": [
         {
             "name": "Damien Alexandre",

--- a/composer.json
+++ b/composer.json
@@ -47,9 +47,6 @@
             "*": "dist"
         },
         "sort-packages": true,
-        "platform": {
-            "php": "7.4.3"
-        },
         "allow-plugins": {
             "symfony/flex": true,
             "symfony/runtime": true

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "type": "project",
     "license": "MIT",
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=8.1",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "jolicode/jolitypo": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f645b913070aabde0e831fa2715543f8",
+    "content-hash": "b309ae3f11dd67bf96f80ddaac00d9ae",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -648,6 +648,7 @@
                 "issues": "https://github.com/sensiolabs/SensioFrameworkExtraBundle/issues",
                 "source": "https://github.com/sensiolabs/SensioFrameworkExtraBundle/tree/v5.6.1"
             },
+            "abandoned": "Symfony",
             "time": "2020-08-25T19:10:18+00:00"
         },
         {
@@ -5233,7 +5234,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.2.5",
+        "php": ">=8.1",
         "ext-ctype": "*",
         "ext-iconv": "*"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b309ae3f11dd67bf96f80ddaac00d9ae",
+    "content-hash": "037d1c205e6e124146e789c429076dc1",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -5239,8 +5239,5 @@
         "ext-iconv": "*"
     },
     "platform-dev": [],
-    "platform-overrides": {
-        "php": "7.4.3"
-    },
     "plugin-api-version": "2.3.0"
 }

--- a/tests/Controller/HomepageControllerTest.php
+++ b/tests/Controller/HomepageControllerTest.php
@@ -12,7 +12,7 @@ class HomepageControllerTest extends WebTestCase
         $client->request('GET', '/');
         $response = $client->getResponse();
 
-        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(200, $response->getStatusCode(), $response->getContent());
     }
 
     public function testSubmitWorks()
@@ -26,7 +26,9 @@ class HomepageControllerTest extends WebTestCase
                 'content' => 'Hello Damien !',
             ]
         ]);
+        $response = $client->getResponse();
 
+        self::assertSame(200, $response->getStatusCode(), $response->getContent());
         self::assertSame(1, $crawler->filter('textarea.form__result-client')->count());
         self::assertSame(1, $crawler->filter('textarea.form__result-html')->count());
     }
@@ -42,7 +44,9 @@ class HomepageControllerTest extends WebTestCase
                 'content' => 'Hello Damien !',
             ]
         ]);
+        $response = $client->getResponse();
 
+        self::assertSame(200, $response->getStatusCode(), $response->getContent());
         self::assertSame(0, $crawler->filter('textarea.form__result-client')->count());
         self::assertSame(0, $crawler->filter('textarea.form__result-html')->count());
         self::assertSame(1, $crawler->filter('html div.error-message', 'This value should not be null.')->count());
@@ -59,7 +63,9 @@ class HomepageControllerTest extends WebTestCase
                 'content' => '',
             ]
         ]);
+        $response = $client->getResponse();
 
+        self::assertSame(200, $response->getStatusCode(), $response->getContent());
         self::assertSame(0, $crawler->filter('textarea.form__result-client')->count());
         self::assertSame(0, $crawler->filter('textarea.form__result-html')->count());
         self::assertSame(1, $crawler->filter('html div.error-message', 'Unfortunately, we can\'t fix what doesn\'t exist ! Please enter something to fix.')->count());


### PR DESCRIPTION
- Remove Heroku from GitHub Actions
- Use PHP 8.1 in the CI
- Bump requirements to PHP 8.1 in composer.json
- Fixed typo in composer.json
- Update GitHub Action actions/checkout from v2 to v3
- Update GitHub Action actions/setup-node from v2 to v3
- Remove hardcoded PHP version in composer.json
- Relax constraints on GitHub Action shivammathur/setup-php

